### PR TITLE
explicitly require macro ns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject rum "0.2.1"
+(defproject rum "0.2.1-SNAPSHOT"
   :description "ClojureScript wrapper for React"
   :url "https://github.com/tonsky/rum"
   :license {:name "Eclipse Public License"

--- a/src/rum.cljs
+++ b/src/rum.cljs
@@ -1,7 +1,7 @@
 (ns rum
-  (:require
-    cljsjs.react
-    sablono.core))
+  (:require-macros rum)
+  (:require [cljsjs.react]
+            [sablono.core]))
 
 (enable-console-print!)
 


### PR DESCRIPTION
I think the wrapping of symbols in `:require` in `[]` might be a bug in CLJS. The `(:require-macros)` form is definitely required with 2755 and above.
