### PR TITLE
Provide component display name

### DIFF
--- a/src/rum.clj
+++ b/src/rum.clj
@@ -24,7 +24,7 @@
   (let [{:keys [name doc mixins argvec render]} (parse-defc body)]
    `(let [render-fn#    (fn ~argvec ~(s/compile-html `(do ~@render)))
           render-mixin# (~render-ctor render-fn#)
-          class#        (rum/build-class (concat [render-mixin#] ~mixins))
+          class#        (rum/build-class (concat [render-mixin#] ~mixins) ~(str name))
           ctor#         (fn ~argvec
                           (let [state# (args->state ~argvec)]
                             (rum/element class# state# nil)))]

--- a/src/rum.cljs
+++ b/src/rum.cljs
@@ -28,7 +28,7 @@
     state
     fns))
 
-(defn build-class [classes]
+(defn build-class [classes display-name]
   (let [init           (fns :init classes)           ;; state props -> state
         will-mount     (fns :will-mount classes)     ;; state -> state
         did-mount      (fns :did-mount classes)      ;; state -> state
@@ -43,6 +43,7 @@
     ]
 
     (js/React.createClass #js {
+      :displayName display-name
       :getInitialState
       (fn []
         (this-as this


### PR DESCRIPTION
Would be helpful to have component display name so you get better reports in React.addons.Perf.
