### PR TITLE
Add state transfering to README mixin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ Sample mixin that forces re-render every second:
                      callback #(rum/request-render comp)
                      interval  (js/setInterval callback 1000)]
                  (assoc state ::interval interval)))
+  :transfer-state (fn [old-state state]
+                    (merge state (select-keys old-state [::interval])))
   :will-unmount (fn [state]
                   (js/clearInterval (::interval state)))})
 

--- a/examples/examples.cljs
+++ b/examples/examples.cljs
@@ -131,6 +131,8 @@
   :did-mount (fn [state]
                (let [interval (js/setInterval #(rum/request-render (:rum/react-component state)) 1000)]
                  (assoc state ::interval interval)))
+  :transfer-state (fn [old-state state]
+                    (merge state (select-keys old-state [::interval])))
   :will-unmount (fn [state]
                   (js/clearInterval (::interval state)))
   })


### PR DESCRIPTION
Current implementation doesn't transfer custom state parameters between component updates. Mixin from README loses ::interval field after updating the component
