### PR TITLE
Allow components to refer to themselves.

### DIFF
--- a/src/rum.clj
+++ b/src/rum.clj
@@ -22,7 +22,8 @@
 
 (defn- -defc [render-ctor body]
   (let [{:keys [name doc mixins argvec render]} (parse-defc body)]
-   `(let [render-fn#    (fn ~argvec ~(s/compile-html `(do ~@render)))
+   `(let [_             (declare ~name)
+          render-fn#    (fn ~argvec ~(s/compile-html `(do ~@render)))
           render-mixin# (~render-ctor render-fn#)
           class#        (rum/build-class (concat [render-mixin#] ~mixins) ~(str name))
           ctor#         (fn [& args#]


### PR DESCRIPTION
Declaring the component name at the top of the let will allow the render
body to invoke the component.

`declare` for side-effects within a let is ugly, but better than the
alternatives:
- No way to replace `let` with `letfn` since the render body won't be
  calling itself.
- Putting the `declare` outside of the let would require the macro
  splicing, which is trickier to understand and requires more syntax
