### PR TITLE
added link to rum-mdl

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ For more examples, see [examples/rum/examples/](examples/rum/examples/). Live ve
 ## Libraries
 
 - [Reforms](http://bilus.github.io/reforms/)
+- [rum-mdl](http://ajchemist.github.io/rum-mdl/)
 
 ## Who’s using Rum?
 


### PR DESCRIPTION
rum-mdl also uses latest `rum/render-static-markup` for index.html gh-pages generation.

https://github.com/aJchemist/rum-mdl/blob/master/build.boot#L71
