### PR TITLE
Throw a helpful exception for bad name

### DIFF
--- a/src/rum/core.clj
+++ b/src/rum/core.clj
@@ -9,6 +9,8 @@
        (vector? (first form))))
 
 (defn- parse-defc [xs]
+  (when-not (instance? clojure.lang.Symbol (first xs))
+    (throw (IllegalArgumentException. "First argument to defc must be a symbol")))
   (loop [res  {}
          xs   xs
          mode nil]

--- a/test/rum/test/defc.clj
+++ b/test/rum/test/defc.clj
@@ -1,0 +1,22 @@
+(ns rum.test.defc
+  (:require
+    [rum.core]
+    [clojure.string :as str]
+    [clojure.test :refer [deftest is are testing]]
+    [clojure.java.shell :as shell]))
+
+(defmacro eval-in-temp-ns [& forms]
+  `(binding [*ns* *ns*]
+     (in-ns (gensym))
+     (clojure.core/use 'clojure.core)
+     (clojure.core/use 'rum.core)
+     (eval
+      '(do ~@forms))))
+
+;; Copied from Clojure: https://git.io/vwFsG
+(deftest defc-error-messages
+  (testing "bad name"
+    (is (thrown-with-msg?
+          IllegalArgumentException
+          #"First argument to defc must be a symbol"
+          (eval-in-temp-ns (defc "bad docstring" testname [arg1 arg2]))))))


### PR DESCRIPTION
Throws a helpful exception if you forget to give your `defc` a name. 

For example, 

``` clojure
(rum/defcs [] < (rum/locals 0) [state] 
  [:div "Hello"])
```

threw an NPE. Now it throws an IllegalArgumentException with "First argument to defc must be a symbol".

I tried some of the other variations from [clojure's def tests ](https://github.com/clojure/clojure/blob/master/test/clojure/test_clojure/def.clj) and they all seemed to have decent error messages. Not great, but enough to give you a good starting point for debugging.

Didn't write a test on the cljs side for this. Happy to try if that's important.
