### PR TITLE
check for conditions in compile-body

### DIFF
--- a/src/rum/core.clj
+++ b/src/rum/core.clj
@@ -39,8 +39,10 @@
           (throw (IllegalArgumentException. (str "Syntax error at " xs)))))))
 
 
-(defn- compile-body [[argvec & body]]
-  (list argvec (s/compile-html `(do ~@body))))
+(defn- compile-body [[argvec conditions & body]]
+  (if (and (map? conditions) (seq body))
+    (list argvec conditions (s/compile-html `(do ~@body)))
+    (list argvec (s/compile-html `(do ~@(cons conditions body))))))
 
 
 (defn- -defc [builder cljs? body]

--- a/test/rum/test/defc.clj
+++ b/test/rum/test/defc.clj
@@ -20,3 +20,29 @@
           IllegalArgumentException
           #"First argument to defc must be a symbol"
           (eval-in-temp-ns (defc "bad docstring" testname [arg1 arg2]))))))
+
+(deftest defc-conditions
+  (testing "no conditions supplied"
+    (is (= '(def pre-post-test
+              (rum.core/build-defc
+               (clojure.core/fn
+                 ([y] (do {:x 1}))
+                 ([y z] (do (sablono.interpreter/interpret (+ y z 1)))))
+               nil
+               "pre-post-test"))
+           (#'rum.core/-defc 'rum.core/build-defc
+                             true ; cljs?
+                             '(pre-post-test ([y] {:x 1})
+                                             ([y z] (+ y z 1)))))))
+  (testing "some conditions supplied"
+    (is (= '(def pre-post-test
+              (rum.core/build-defc
+               (clojure.core/fn
+                 ([y] {:pre [(pos? y)]} (do {:x 1}))
+                 ([y z] (do (sablono.interpreter/interpret (+ y z 1)))))
+               nil
+               "pre-post-test"))
+           (#'rum.core/-defc 'rum.core/build-defc
+                             true ; cljs?
+                             '(pre-post-test ([y] {:pre [(pos? y)]} {:x 1})
+                                             ([y z] (+ y z 1))))))))


### PR DESCRIPTION
This adds support for `{:pre [] :post []}` in ClojureScript. Previously this worked in Clojure but not in CLJS.

I still want to add some tests but opening this early won't hurt I guess.
