### PR TITLE
Move derived-atom docstring

### DIFF
--- a/src/rum/core.clj
+++ b/src/rum/core.clj
@@ -197,7 +197,7 @@
   ^rum.cursor.Cursor [ref key & options]
   (apply cursor-in ref [key] options))
 
-(def derived-atom
+(def ^{:style/indent 2} derived-atom
   "Use this to create “chains” and acyclic graphs of dependent atoms.
    `derived-atom` will:
     - Take N “source” refs

--- a/src/rum/core.clj
+++ b/src/rum/core.clj
@@ -197,8 +197,41 @@
   ^rum.cursor.Cursor [ref key & options]
   (apply cursor-in ref [key] options))
 
+(def derived-atom
+  "Use this to create “chains” and acyclic graphs of dependent atoms.
+   `derived-atom` will:
+    - Take N “source” refs
+    - Set up a watch on each of them
+    - Create “sink” atom
+    - When any of source refs changes:
+       - re-run function `f`, passing N dereferenced values of source refs
+       - `reset!` result of `f` to the sink atom
+    - return sink atom
 
-(def derived-atom derived-atom/derived-atom)
+    (def *a (atom 0))
+    (def *b (atom 1))
+    (def *x (derived-atom [*a *b] ::key
+              (fn [a b]
+                (str a \":\" b))))
+    (type *x) ;; => clojure.lang.Atom
+    \\@*x     ;; => 0:1
+    (swap! *a inc)
+    \\@*x     ;; => 1:1
+    (reset! *b 7)
+    \\@*x     ;; => 1:7
+
+   Arguments:
+     refs - sequence of source refs
+     key  - unique key to register watcher, see `clojure.core/add-watch`
+     f    - function that must accept N arguments (same as number of source refs)
+            and return a value to be written to the sink ref.
+            Note: `f` will be called with already dereferenced values
+     opts - optional. Map of:
+       :ref           - Use this as sink ref. By default creates new atom
+       :check-equals? - Do an equality check on each update: `(= @sink (f new-vals))`.
+                        If result of `f` is equal to the old one, do not call `reset!`.
+                        Defaults to `true`. Set to false if calling `=` would be expensive"
+  derived-atom/derived-atom)
 
 
 ;;; Server-side rendering

--- a/src/rum/core.cljs
+++ b/src/rum/core.cljs
@@ -302,7 +302,7 @@
 
 ;; derived-atom
 
-(def derived-atom
+(def ^{:style/indent 2} derived-atom
   "Use this to create “chains” and acyclic graphs of dependent atoms.
    `derived-atom` will:
     - Take N “source” refs

--- a/src/rum/core.cljs
+++ b/src/rum/core.cljs
@@ -302,7 +302,41 @@
 
 ;; derived-atom
 
-(def derived-atom derived-atom/derived-atom)
+(def derived-atom
+  "Use this to create “chains” and acyclic graphs of dependent atoms.
+   `derived-atom` will:
+    - Take N “source” refs
+    - Set up a watch on each of them
+    - Create “sink” atom
+    - When any of source refs changes:
+       - re-run function `f`, passing N dereferenced values of source refs
+       - `reset!` result of `f` to the sink atom
+    - return sink atom
+
+    (def *a (atom 0))
+    (def *b (atom 1))
+    (def *x (derived-atom [*a *b] ::key
+              (fn [a b]
+                (str a \":\" b))))
+    (type *x) ;; => clojure.lang.Atom
+    \\@*x     ;; => 0:1
+    (swap! *a inc)
+    \\@*x     ;; => 1:1
+    (reset! *b 7)
+    \\@*x     ;; => 1:7
+
+   Arguments:
+     refs - sequence of source refs
+     key  - unique key to register watcher, see `clojure.core/add-watch`
+     f    - function that must accept N arguments (same as number of source refs)
+            and return a value to be written to the sink ref.
+            Note: `f` will be called with already dereferenced values
+     opts - optional. Map of:
+       :ref           - Use this as sink ref. By default creates new atom
+       :check-equals? - Do an equality check on each update: `(= @sink (f new-vals))`.
+                        If result of `f` is equal to the old one, do not call `reset!`.
+                        Defaults to `true`. Set to false if calling `=` would be expensive"
+  derived-atom/derived-atom)
 
 
 ;; cursors

--- a/src/rum/derived_atom.cljc
+++ b/src/rum/derived_atom.cljc
@@ -2,39 +2,6 @@
 
 
 (defn derived-atom
-  "Use this to create “chains” and acyclic graphs of dependent atoms.
-   `derived-atom` will:
-    - Take N “source” refs
-    - Set up a watch on each of them
-    - Create “sink” atom
-    - When any of source refs changes:
-       - re-run function `f`, passing N dereferenced values of source refs
-       - `reset!` result of `f` to the sink atom
-    - return sink atom
-  
-    (def *a (atom 0))
-    (def *b (atom 1))
-    (def *x (derived-atom [*a *b] ::key
-              (fn [a b]
-                (str a \":\" b))))
-    (type *x) ;; => clojure.lang.Atom
-    \\@*x     ;; => 0:1
-    (swap! *a inc)
-    \\@*x     ;; => 1:1
-    (reset! *b 7)
-    \\@*x     ;; => 1:7
-  
-   Arguments:
-     refs - sequence of source refs
-     key  - unique key to register watcher, see `clojure.core/add-watch`
-     f    - function that must accept N arguments (same as number of source refs)
-            and return a value to be written to the sink ref.
-            Note: `f` will be called with already dereferenced values
-     opts - optional. Map of:
-       :ref           - Use this as sink ref. By default creates new atom
-       :check-equals? - Do an equality check on each update: `(= @sink (f new-vals))`.
-                        If result of `f` is equal to the old one, do not call `reset!`.
-                        Defaults to `true`. Set to false if calling `=` would be expensive"
   ([refs key f]
     (derived-atom refs key f {}))
   ([refs key f opts]


### PR DESCRIPTION
Move the docstring so it can be seen by end-users, also add indentation metadata.
