### PR TITLE
add assert to fail when rum/react is used w/o reactive mixin

### DIFF
--- a/src/rum/core.cljs
+++ b/src/rum/core.cljs
@@ -296,6 +296,7 @@
    `deref` inside render, and your component will subscribe to changes happening
    to the derefed atom."
   [ref]
+  (assert *reactions* "rum.core/react is only supported in conjunction with rum.core/reactive")
   (vswap! *reactions* conj ref)
   @ref)
 


### PR DESCRIPTION
fixes #82 

It's the most obvious thing that came to mind, let me know you have alternative suggestions.
