### PR TITLE
throw exception when first fn-body is `<`

### DIFF
--- a/src/rum/core.clj
+++ b/src/rum/core.clj
@@ -11,8 +11,11 @@
 
 
 (defn- fn-body? [form]
-  (and (seq? form)
-       (vector? (first form))))
+  (when (and (seq? form)
+             (vector? (first form)))
+    (if (= '< (second form))
+      (throw (IllegalArgumentException. "Mixins must be given before argument list"))
+      true)))
 
 
 (defn- parse-defc

--- a/test/rum/test/defc.clj
+++ b/test/rum/test/defc.clj
@@ -19,7 +19,24 @@
     (is (thrown-with-msg?
           IllegalArgumentException
           #"First argument to defc must be a symbol"
-          (eval-in-temp-ns (defc "bad docstring" testname [arg1 arg2]))))))
+          (eval-in-temp-ns (defc "bad docstring" testname [arg1 arg2])))))
+  (testing "mixins after argvec"
+    (is (thrown-with-msg?
+         IllegalArgumentException
+         #"Mixins must be given before argument list"
+         (eval-in-temp-ns (defc testname "docstring" [arg1 arg2] < misplaced-mixin))))
+    (is (thrown-with-msg?
+         IllegalArgumentException
+         #"Mixins must be given before argument list"
+         (eval-in-temp-ns (defc testname "docstring"
+                            ([arg1] < misplaced-mixin)
+                            ([arg1 arg2] < misplaced-mixin)))))
+    (is (thrown-with-msg?
+         IllegalArgumentException
+         #"Mixins must be given before argument list"
+         (eval-in-temp-ns (defc testname
+                            ([arg1] < misplaced-mixin)
+                            ([arg1 arg2] < misplaced-mixin)))))))
 
 (deftest defc-conditions
   (testing "no conditions supplied"


### PR DESCRIPTION
via #88 

Sometimes users might mix up the order of mixins and argument vector. This patch throws an exception when the first form in the function body is a `<`.

This can lead to false positives of course but I don't yet see a reason why anyone would have a plain `<` at the beginning of their functions. If users report that this is an issue we can always fix it later for now I believe this is a great improvement for beginners/people getting started with Rum.
