### PR TITLE
server rendering: escape attributes, like React does

### DIFF
--- a/src/rum/server_render.clj
+++ b/src/rum/server_render.clj
@@ -349,7 +349,7 @@
       (true? value)    (append! sb " " attr "=\"\"")
       (.startsWith attr "on")            :nop
       (= "dangerouslySetInnerHTML" attr) :nop
-      :else            (append! sb " " attr "=\"" (to-str value) "\""))))
+      :else            (append! sb " " attr "=\"" (escape-html (to-str value)) "\""))))
 
 
 (defn render-attrs! [tag attrs sb]


### PR DESCRIPTION
React escapes element attributes, see here: https://github.com/facebook/react/blob/v15.3.2/src/renderers/dom/shared/DOMPropertyOperations.js#L102