### PR TITLE
README: Add Lupapiste to "Who’s using Rum?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Rum:
 - [PurposeFly](https://www.purposefly.com/), HR 2.0 platform
 - [Simply](https://www.simply.co.za), Simple direct life insurance
 - [Oscaro.com](https://www.oscaro.com), online autoparts retailer
+- [Lupapiste](https://github.com/lupapiste/lupapiste), building permit issuance and management 
 
 ## Using Rum
 


### PR DESCRIPTION
Hi,

we've been using Rum as our front-end library of choice when implementing new UI components in our Lupapiste ("Permit Point") building permit service. The code is open source, so I'd like to add a link to our Github project page to the Rum readme.

BR,
Markus / Lupapiste (Evolta Ltd.)