### PR TITLE
Use https to for rum_logo.svg in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="http://s.tonsky.me/imgs/rum_logo.svg" style="height: 400px;"></p>
+<p align="center"><img src="https://s.tonsky.me/imgs/rum_logo.svg" style="height: 400px;"></p>
 
 Rum is a client/server library for HTML UI. In ClojureScript, it works as React wrapper, in Clojure, it is a static HTML generator.
 


### PR DESCRIPTION
Not a big deal but gave me mixed content warnings [here](https://cljdoc.xyz/d/rum/rum/0.11.2/doc/readme) so I figured I could open a PR.