### PR TITLE
Changed collect and collect* to return a vector.

### DIFF
--- a/src/rum/util.cljc
+++ b/src/rum/util.cljc
@@ -2,13 +2,15 @@
 
 
 (defn collect [key mixins]
-  (->> (map (fn [m] (get m key)) mixins)
-       (remove nil?)))
+  (into []
+        (keep (fn [m] (get m key)))
+        mixins))
 
 
 (defn collect* [keys mixins]
-  (->> (mapcat (fn [m] (map (fn [k] (get m k)) keys)) mixins)
-       (remove nil?)))
+  (into []
+        (mapcat (fn [m] (keep (fn [k] (get m k)) keys)))
+        mixins))
 
 
 (defn call-all [state fns & args]


### PR DESCRIPTION
`rum.util.collect` and `rum.util.collect*` are returning lazy sequences, which are then attached to the components to be later used when events trigger. IMHO, the lazyness does not bring any advantage in this situation and may be wasting CPU.

This PR is changing those 2 functions so that they provide vectors instead.

I also adjusted the code a little bit to use `keep` instead of `map`, to avoid having to use `(remove nil?)` afterward.