### PR TITLE
Fix render-all to forbid forceUpdate on falsy comp

### DIFF
--- a/src/rum/core.cljs
+++ b/src/rum/core.cljs
@@ -193,7 +193,7 @@
 
 (defn- render-all [queue]
   (doseq [comp queue
-          :when (not (gobj/get comp ":rum/unmounted?"))]
+          :when (and (some? comp) (not (gobj/get comp ":rum/unmounted?")))]
     (.forceUpdate comp)))
 
 


### PR DESCRIPTION
The `when` condition passes in following situations:
- component is unmounted 
- when it's a falsy value (nil, false)
This commit forbids exec of forceRender on falsy components, so such an action will not trigger an error.

https://imgur.com/a/SB6ys2E