### PR TITLE
Add wrapper for React.createRef

### DIFF
--- a/examples/rum/examples/refs.cljc
+++ b/examples/rum/examples/refs.cljc
@@ -1,18 +1,19 @@
 (ns rum.examples.refs
   (:require
-   [rum.core :as rum]
-   [rum.examples.core :as core]))
+   [rum.core :as rum]))
+
+(def ta-ref (rum/create-ref))
 
 (rum/defcc ta
   < {:after-render
      (fn [state]
-       (let [ta (rum/ref-node state "ta")]
-         (set! (.-height (.-style ta)) "0")
-         (set! (.-height (.-style ta)) (str (+ 2 (.-scrollHeight ta)) "px")))
-       state)}
+       (let [el (rum/deref ta-ref)
+             _  (set! (.-height (.-style el)) "0")
+             _  (set! (.-height (.-style el)) (str (+ 2 (.-scrollHeight el)) "px"))]
+         state))}
   [comp]
   [:textarea
-   {:ref :ta
+   {:ref ta-ref
     :style {:width   "100%"
             :padding "10px"
             :font    "inherit"

--- a/src/rum/core.clj
+++ b/src/rum/core.clj
@@ -385,6 +385,11 @@
 (defn use-ref [initial-value]
   (atom initial-value))
 
+;; Refs
+
+(defn create-ref []
+  (atom nil))
+
 (defn deref [ref]
   @ref)
 

--- a/src/rum/core.cljs
+++ b/src/rum/core.cljs
@@ -567,6 +567,11 @@
   ([initial-value]
    (.useRef js/React initial-value)))
 
+;; Refs
+
+(defn create-ref []
+  (.createRef js/React))
+
 (defn deref
   "Takes a ref returned from use-ref and returns its current value."
   [^js ref]


### PR DESCRIPTION
It turned out that `createRef` doesn't take in any value. It just [creates](https://github.com/facebook/react/blob/master/packages/react/src/ReactCreateRef.js) a new object with empty `current`.

Also I haven't recompiled `main.js` to avoid potential conflicts, should I do that?

Closes #204.