### PR TITLE
Add missing did-update

### DIFF
--- a/src/rum/specs.cljc
+++ b/src/rum/specs.cljc
@@ -2,6 +2,6 @@
 
 (def mixins
   #{:init :will-mount :before-render :wrap-render :did-mount
-    :after-render :did-remount :should-update :will-update
+    :after-render :did-remount :should-update :will-update :did-update
     :did-update :did-catch :will-unmount :child-context
     :class-properties :static-properties :key-fn})


### PR DESCRIPTION
I feel that did-update was not included in specs due to mistake (check #217). Rum seems to collect did-update mixins from the component definition.