### PR TITLE
#233 Fix warnings not being disabled on shadow-cljs

### DIFF
--- a/src/daiquiri/compiler.clj
+++ b/src/daiquiri/compiler.clj
@@ -44,7 +44,10 @@
   "Infer the tag of `form` using `env`."
   [env form]
   (when env
-    (let [e (with-bindings* {(requiring-resolve 'cljs.analyzer/*cljs-warnings*) {}}
+    (let [*analyzer-warnings* (requiring-resolve 'cljs.analyzer/*cljs-warnings*)
+          ;; We would want to use cljs.analyzer/no-warn here but we can't since
+          ;; it's a macro and won't work with requiring-resolve
+          e (with-bindings* {*analyzer-warnings* (zipmap (keys @*analyzer-warnings*) (repeat false))}
               (fn []
                 ((requiring-resolve 'cljs.analyzer/analyze) env form)))
           ;; Roman. Propagating Rum's component return tag


### PR DESCRIPTION
See #233

This basically just replicates the implementation of the `cljs.analyzer/no-warn` macro. Instead of changing the warning map to an empty map, it sets all warnings to `false`.