### PR TITLE
add ^js typehint to React Context

### DIFF
--- a/src/rum/core.clj
+++ b/src/rum/core.clj
@@ -363,9 +363,11 @@
     ...)"
   [[context value] & body]
   (if (:ns &env)
-    `(.createElement js/React (.-Provider ~context)
-                     (cljs.core/js-obj "value" ~value)
-                     ~@(map #(compiler/compile-html % &env) body))
+    (let [ctx (with-meta (gensym "ctx") {:tag 'js})]
+      `(let [~ctx ~context]
+         (.createElement js/React (.-Provider ~ctx)
+                         (cljs.core/js-obj "value" ~value)
+                         ~@(map #(compiler/compile-html % &env) body))))
     `(binding [~context ~value]
        ~@body)))
 


### PR DESCRIPTION
Generates a `^js` type-hint for the `context` form within the `bind-context` macro 
Inspired by https://clojureverse.org/t/clojurescript-macros-and-type-hints/7292

Solves errors like 
<img width="592" alt="image" src="https://user-images.githubusercontent.com/35239179/191106444-5d5b3dcb-ef03-45d7-bd82-a9586b4c80ce.png">

Fixes #251 
cc: @martinklepsch 