### PR TITLE
Fix *cljs-file* not showing in warning messages

### DIFF
--- a/src/daiquiri/compiler.clj
+++ b/src/daiquiri/compiler.clj
@@ -20,7 +20,7 @@
        (let [column (:column env)
              line (:line env)]
          (require 'cljs.analyzer)
-         (println (str "WARNING: interpreting by default at " (requiring-resolve 'cljs.analyzer/*cljs-file*) ":" line ":" column))
+         (println (str "WARNING: interpreting by default at " (some-> (requiring-resolve 'cljs.analyzer/*cljs-file*) deref) ":" line ":" column))
          (prn expr)
          (when tag
            (println "Inferred tag was:" tag)))))))


### PR DESCRIPTION
file-names in warning messages are not showing properly

- `(rum/set-warn-on-interpretation! true)`
-  `WARNING: interpreting by default at #'cljs.analyzer/*cljs-file*:189:1`